### PR TITLE
Please shellcheck and increase portability/reliability

### DIFF
--- a/b42_prepush_check.sh
+++ b/b42_prepush_check.sh
@@ -11,9 +11,9 @@ git_root="$(git rev-parse --show-toplevel)"
 
 summary_status=""
 
-pushd -- "$git_root" >/dev/null || {  echo "Couldn't change directory!"; exit 2; }
+pushd "$git_root" >/dev/null || {  echo "Couldn't change directory!"; exit 2; }
 echo "== NORM"
-"$(type -P norminette)"
+norminette
 norminette_status=$?
 summary_status="${summary_status}.${norminette_status}"
 
@@ -37,7 +37,7 @@ not_found=0
 OLDIFS="${IFS}"
 IFS=$'\n'
 for fname in $(find . -name 'ft_*.c'); do
-	func_name="$(basename -- "$fname" .c)"
+	func_name="$(basename -s .c -- "$fname")"
 	# grep "^/.*$func_name" "$fname"	# Check for fname in header
 	grep -EH "^(char|int|void|long)\s+\**${func_name}\(" "$fname" # Check for the function declaration
 	rc=$?

--- a/b42_prepush_check.sh
+++ b/b42_prepush_check.sh
@@ -1,22 +1,27 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-RED='\033[0;91m'
-GREEN='\033[0;32m'
-NC='\033[0m' # No Color
+# Needed for type builtin and globstar shell option
+[ -z "$BASH_VERSION" ] && { echo "Script must be run with bash!"; exit 1; }
 
-git_root=$(git rev-parse --show-toplevel)
+RED='\033[91m'
+GREEN='\033[32m'
+NC='\033[m' # No Color
+
+git_root="$(git rev-parse --show-toplevel)"
 
 summary_status=""
 
-pushd "$git_root"
+pushd -- "$git_root" >/dev/null || {  echo "Couldn't change directory!"; exit 2; }
 echo "== NORM"
-norminette
+"$(type -P norminette)"
 norminette_status=$?
 summary_status="${summary_status}.${norminette_status}"
 
 echo "== CC"
-cc -Wall -Wextra -Werror -c */*.c
+shopt -s globstar
+cc -Wall -Wextra -Werror -c ./**/*.c
 cc_status=$?
+shopt -u globstar
 summary_status="${summary_status}.${cc_status}"
 
 echo "== Files in repo"
@@ -29,16 +34,19 @@ summary_status="${summary_status}.${uncommited_status}"
 
 echo "== Filename to function name"
 not_found=0
+OLDIFS="${IFS}"
+IFS=$'\n'
 for fname in $(find . -name 'ft_*.c'); do
-	func_name=$(basename -s .c $fname);
+	func_name="$(basename -- "$fname" .c)"
 	# grep "^/.*$func_name" "$fname"	# Check for fname in header
-	egrep -H "^(char|int|void)\s+\*?$func_name\(" $fname # Check for the function declaration
+	grep -EH "^(char|int|void|long)\s+\*+${func_name}\(" "$fname" # Check for the function declaration
 	rc=$?
-	not_found=$((not_found + $rc))
+	not_found=$((not_found + rc))
 	if [ $rc -ne 0 ]; then
-		echo -e "$RED$fname$NC: not found declaration for the function $GREEN${func_name}$NC"
+		echo -e "${RED}${fname}${NC}: can't find declaration for the function ${GREEN}${func_name}${NC}"
 	fi
 done
+IFS="${OLDIFS}"
 summary_status="${summary_status}.${not_found}"
 
 summary_status="${summary_status}."
@@ -46,10 +54,10 @@ summary_status_filtered=$(echo "$summary_status" | tr -d '.0')
 echo "Checks summary code: ${summary_status}"
 if [ "$summary_status_filtered" != "" ];
 then
-	echo -e "$RED## SOME STEPS CAN BE IMPROVED."
-	echo -e "Do you mind to take a deeper look there?$NC"
+	echo -e "${RED}## SOME STEPS CAN BE IMPROVED."
+	echo -e "Do you mind to take a deeper look there?${NC}"
 else
-	echo -e "$GREEN## I THINK ALL GOOD HERE AT $git_root."
-	echo -e "Good luck with evaluations!$NC"
+	echo -e "${GREEN}## I THINK ALL GOOD HERE AT ${git_root}."
+	echo -e "Good luck with evaluations!${NC}"
 fi
-popd
+popd >/dev/null || {  echo "Couldn't change directory!"; exit 3; }

--- a/b42_prepush_check.sh
+++ b/b42_prepush_check.sh
@@ -39,7 +39,7 @@ IFS=$'\n'
 for fname in $(find . -name 'ft_*.c'); do
 	func_name="$(basename -- "$fname" .c)"
 	# grep "^/.*$func_name" "$fname"	# Check for fname in header
-	grep -EH "^(char|int|void|long)\s+\*+${func_name}\(" "$fname" # Check for the function declaration
+	grep -EH "^(char|int|void|long)\s+\**${func_name}\(" "$fname" # Check for the function declaration
 	rc=$?
 	not_found=$((not_found + rc))
 	if [ $rc -ne 0 ]; then


### PR DESCRIPTION
- `*/*.c` only matches C-files in immediate subdirectories. Enabling globstar and globbing for `**/*.c` matches all C-files, recursively, if that is wanted
- `norminette` on it's own might be prone to aliases or functions. `"$(type -P norminette)"` counters that
- quoted some command substitutions that might expand to something that contains spaces
- exit if pushd fails (shellcheck)
- turn obsolete `[ p1 -o p2 ]` syntax to `[ p1 ] || [ p2 ]` (shellcheck)
- ignore `pushd`/`popd` stdout
- make shebang portable
- add braces to some variable expansions to prevent accidents
- set IFS to `\n` in case directories contain spaces
- add long as a possible function return type
- add `--` guard for basename command (I hope this works on BSD)
- change `?` to `+` in regex since a function can return a pointer to a pointer (etc.). See ft_split
- change obsolete `egrep` to `grep -E`